### PR TITLE
clearing old text or download links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -251,6 +251,8 @@
         }
         
         function generateKeys(event) {
+            document.getElementById('key-results').style.display = 'none';
+            
             const p = document.getElementById('p').value;
             const q = document.getElementById('q').value;
             const button = event.currentTarget;
@@ -316,6 +318,10 @@
         }
         
         function encryptMessage() {
+            document.getElementById('encrypt-results').style.display = 'none';
+            document.getElementById('encrypted-result').textContent = '';
+            document.getElementById('encrypt-download').href = '#';
+
             const N = document.getElementById('encrypt-N').value;
             const e = document.getElementById('encrypt-e').value;
             const message = document.getElementById('encrypt-message').value;
@@ -360,6 +366,10 @@
         }
         
         function decryptMessage() {
+            document.getElementById('decrypt-results').style.display = 'none';
+            document.getElementById('decrypted-result').textContent = '';
+            document.getElementById('decrypt-download').href = '#';
+
             const N = document.getElementById('decrypt-N').value;
             const d = document.getElementById('decrypt-d').value;
             const message = document.getElementById('decrypt-message').value;


### PR DESCRIPTION
## 📝 Pull Request Summary

🎯 Goal
Ensure that old results (text or download links) are cleared/hidden whenever the user tries a new action — to avoid confusion from stale data.

## 📌 Related Issue
#24 




## 🔍 Type of Change

updated three functions:

1)generateKeys()

2)encryptMessage()

3)decryptMessage()

Each will get a line (or two) at the very start of the function to clear previous results.


Please check the relevant option(s):

- [ ] 🐞 Bug fix
- [x] ✨ Feature
- [ ] 📝 Documentation
- [ ] 🎨 UI enhancement



## ✅ Checklist

- [x] I have tested these changes locally.
- [ ] I have added relevant documentation/comments.
- [x] My code follows the style guidelines of this project.
- [ ] I have reviewed and updated existing tests or added new ones as needed.

---

